### PR TITLE
[tests] Remove EGL_KHR_image_pixmap again

### DIFF
--- a/src/test_enum_eglextensions.c
+++ b/src/test_enum_eglextensions.c
@@ -25,7 +25,6 @@
 static const char* egl_ext_list[] =
 {
 	"EGL_WL_bind_wayland_display",
-	"EGL_KHR_image_pixmap",
 	NULL
 };
 


### PR DESCRIPTION
We don't have pixmaps, i misread the Wayland spec.
