### PR TITLE
Add support for testing on fbdev

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -29,6 +29,7 @@ h_sources = \
 c_sources = \
 	ogles2_helper.c \
 	ogles2_helper_wayland.c \
+	ogles2_helper_fbdev.c \
 	ogles2_conf_file.c \
 	test_simple_tri.c \
 	test_enum_glextensions.c \

--- a/src/ogles2_helper.h
+++ b/src/ogles2_helper.h
@@ -205,12 +205,20 @@ double glesh_time_step();
 unsigned char* glesh_generate_pattern(const int width, const int height,
 	const int offset, const GLenum format);
 
-/* Wayland-specific context creation */
-int glesh_create_context_wayland(glesh_context* context,
-	const EGLint attribList[], int window_width, int window_height,
-	int depth);
-int glesh_destroy_context_wayland(glesh_context* context);
-int glesh_main_loop_step_wayland(glesh_context *context);
+/* Context-specific functions */
+enum glesh_ws_context_type {
+	GLESH_WS_CONTEXT_INVALID = 0,
+	GLESH_WS_CONTEXT_WAYLAND,
+	GLESH_WS_CONTEXT_FBDEV,
+};
+void glesh_set_ws_context_type(enum glesh_ws_context_type type);
+
+struct glesh_ws_context_functions {
+	int (*create_context)(glesh_context *context,
+			int window_width, int window_height, int depth);
+	int (*destroy_context)(glesh_context *context);
+	int (*main_loop_step)(glesh_context *context);
+};
 
 #endif // OGLES2_HELPER
 

--- a/src/ogles2_helper_fbdev.c
+++ b/src/ogles2_helper_fbdev.c
@@ -1,0 +1,62 @@
+/* ogles2_helper_fbdev.c -- fbdev-specific helper functions for GLES2
+
+   Copyright (C) 2013 Jolla Ltd.
+   Contact: Thomas Perl <thomas.perl@jollamobile.com>
+
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, version 2.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+*/
+
+#include "ogles2_helper.h"
+
+
+int glesh_create_context_fbdev(glesh_context* context,
+		int window_width,
+		int window_height,
+		int depth)
+{
+	if(!depth)
+	{
+		context->depth = 32;
+	}
+	else
+	{
+		context->depth = depth;
+	}
+
+	/**
+	 * No support for window_width and window_height on fbdev.
+	 * The fbdev device will always be fullscreen.
+	 **/
+
+	context->egl_native_display = EGL_DEFAULT_DISPLAY;
+	context->egl_native_window = NULL;
+
+	return 1;
+}
+
+int glesh_destroy_context_fbdev(glesh_context* context)
+{
+	return 1;
+}
+
+int glesh_main_loop_step_fbdev(glesh_context *context)
+{
+	return 1;
+}
+
+struct glesh_ws_context_functions glesh_fbdev = {
+	glesh_create_context_fbdev,
+	glesh_destroy_context_fbdev,
+	glesh_main_loop_step_fbdev,
+};

--- a/src/ogles2_helper_wayland.c
+++ b/src/ogles2_helper_wayland.c
@@ -160,7 +160,6 @@ wayland_shell_surface_listener = {
 
 
 int glesh_create_context_wayland(glesh_context* context,
-		const EGLint attribList[],
 		int window_width,
 		int window_height,
 		int depth)
@@ -284,3 +283,9 @@ int glesh_main_loop_step_wayland(glesh_context *context)
 	wl_display_dispatch_pending(context->wayland_display);
 	return 1;
 }
+
+struct glesh_ws_context_functions glesh_wayland = {
+	glesh_create_context_wayland,
+	glesh_destroy_context_wayland,
+	glesh_main_loop_step_wayland,
+};

--- a/src/ogles2_perf_test.c
+++ b/src/ogles2_perf_test.c
@@ -32,12 +32,13 @@ static void blts_gles2_help(const char* help_msg_base)
 {
 	fprintf(stdout, help_msg_base,
 		"[-t execution_time_in_seconds] [-w window_width] [-h window_height]"
-		"[-d depth] [-c]"
+		"[-d depth] [-c] [-ws wayland|fbdev]"
 		,
 		"-t: Maximum execution time of each test in seconds (default: 10s)\n"
 		"-w: Used window width. If 0 uses desktop width. (default: 0)\n"
 		"-h: Used window height. If 0 uses desktop height. (default: 0)\n"
 		"-d: Used window depth. 16, 24 or 32. If 0 uses desktop depth. (default: 0)\n"
+		"-ws: Used window system. wayland or fbdev. (default: wayland)\n"
 		);
 }
 
@@ -48,6 +49,7 @@ static void* blts_gles2_argument_processor(int argc, char **argv)
 	memset(params, 0, sizeof(test_execution_params));
 
 	params->execution_time = 10;
+	params->ws = GLESH_WS_CONTEXT_WAYLAND;
 
 	for(t = 1; t < argc; t++)
 	{
@@ -71,6 +73,18 @@ static void* blts_gles2_argument_processor(int argc, char **argv)
 			if(++t >= argc) return NULL;
 			params->d = atoi(argv[t]);
 		}
+		else if(strcmp(argv[t], "-ws") == 0)
+		{
+			if(++t >= argc) return NULL;
+
+			if(strcmp(argv[t], "wayland") == 0) {
+				params->ws = GLESH_WS_CONTEXT_WAYLAND;
+			} else if (strcmp(argv[t], "fbdev") == 0) {
+				params->ws = GLESH_WS_CONTEXT_FBDEV;
+			} else {
+				return NULL;
+			}
+		}
 		else
 		{
 			return NULL;
@@ -78,6 +92,7 @@ static void* blts_gles2_argument_processor(int argc, char **argv)
 	}
 
 	blts_cli_set_timeout((params->execution_time + 30) * 1000);
+	glesh_set_ws_context_type(params->ws);
 
 	return params;
 }

--- a/src/test_common.h
+++ b/src/test_common.h
@@ -21,6 +21,8 @@
 
 #include <limits.h>
 
+#include "ogles2_helper.h"
+
 #define MAX_CONV_MAT_SIZE 128
 
 typedef struct
@@ -47,6 +49,7 @@ typedef struct
 	int h;
 	int d;
 	int flag;
+	enum glesh_ws_context_type ws;
 	test_configuration_file_params config;
 } test_execution_params;
 

--- a/tests.xml
+++ b/tests.xml
@@ -18,32 +18,61 @@
 -->
 <testdefinition version="1.0">
   <suite name="blts-opengles2-tests" domain="Graphics">
-    <set name="gles2-smoke" feature="OpenGL ES 2">
+    <set name="gles2-smoke-wayland" feature="OpenGL ES 2 (Wayland)">
       <case name="OpenGL-Enumerate GL extensions"
         description="Lists all GL extensions"
         type="Functional positive">
-        <step>/opt/tests/blts-opengles2-tests/bin/blts-opengles2-tests -C /opt/tests/blts-opengles2-tests/cnf/blts-opengles2-perf.cnf -l /var/log/tests/blts/OpenGL-Enumerate_GL_extensions.log -en "OpenGL-Enumerate GL extensions"</step>
+        <step>/opt/tests/blts-opengles2-tests/bin/blts-opengles2-tests -C /opt/tests/blts-opengles2-tests/cnf/blts-opengles2-perf.cnf -l /var/log/tests/blts/OpenGL-Enumerate_GL_extensions_wayland.log -en "OpenGL-Enumerate GL extensions" -ws wayland</step>
       </case>
       <case name="OpenGL-Enumerate EGL extensions"
         description="Lists all EGL extensions"
         type="Functional positive">
-        <step>/opt/tests/blts-opengles2-tests/bin/blts-opengles2-tests -C /opt/tests/blts-opengles2-tests/cnf/blts-opengles2-perf.cnf -l /var/log/tests/blts/OpenGL-Enumerate_EGL_extensions.log -en "OpenGL-Enumerate EGL extensions"</step>
+        <step>/opt/tests/blts-opengles2-tests/bin/blts-opengles2-tests -C /opt/tests/blts-opengles2-tests/cnf/blts-opengles2-perf.cnf -l /var/log/tests/blts/OpenGL-Enumerate_EGL_extensions_wayland.log -en "OpenGL-Enumerate EGL extensions" -ws wayland</step>
       </case>
       <case name="OpenGL-Enumerate EGL configs"
         description="Lists all EGL configurations"
         type="Functional positive">
-        <step>/opt/tests/blts-opengles2-tests/bin/blts-opengles2-tests -C /opt/tests/blts-opengles2-tests/cnf/blts-opengles2-perf.cnf -l /var/log/tests/blts/OpenGL-Enumerate_EGL_configs.log -en "OpenGL-Enumerate EGL configs"</step>
+        <step>/opt/tests/blts-opengles2-tests/bin/blts-opengles2-tests -C /opt/tests/blts-opengles2-tests/cnf/blts-opengles2-perf.cnf -l /var/log/tests/blts/OpenGL-Enumerate_EGL_configs_wayland.log -en "OpenGL-Enumerate EGL configs" -ws wayland</step>
       </case>
       <case name="OpenGL-Simple triangle"
         description="Draws simple three vertex rotating triangle"
         type="Functional positive">
-        <step>/opt/tests/blts-opengles2-tests/bin/blts-opengles2-tests -C /opt/tests/blts-opengles2-tests/cnf/blts-opengles2-perf.cnf -l /var/log/tests/blts/OpenGL-Simple_triangle.log -en "OpenGL-Simple triangle"</step>
+        <step>/opt/tests/blts-opengles2-tests/bin/blts-opengles2-tests -C /opt/tests/blts-opengles2-tests/cnf/blts-opengles2-perf.cnf -l /var/log/tests/blts/OpenGL-Simple_triangle_wayland.log -en "OpenGL-Simple triangle" -ws wayland</step>
       </case>
       <get>
-        <file>"/var/log/tests/blts/OpenGL-Enumerate_GL_extensions.log"</file>
-        <file>"/var/log/tests/blts/OpenGL-Enumerate_EGL_extensions.log"</file>
-        <file>"/var/log/tests/blts/OpenGL-Enumerate_EGL_configs.log"</file>
-        <file>"/var/log/tests/blts/OpenGL-Simple_triangle.log"</file>
+        <file>/var/log/tests/blts/OpenGL-Enumerate_GL_extensions_wayland.log</file>
+        <file>/var/log/tests/blts/OpenGL-Enumerate_EGL_extensions_wayland.log</file>
+        <file>/var/log/tests/blts/OpenGL-Enumerate_EGL_configs_wayland.log</file>
+        <file>/var/log/tests/blts/OpenGL-Simple_triangle_wayland.log</file>
+      </get>
+    </set>
+
+    <set name="gles2-smoke-fbdev" feature="OpenGL ES 2 (fbdev)">
+      <case name="OpenGL-Enumerate GL extensions"
+        description="Lists all GL extensions"
+        type="Functional positive">
+        <step>/opt/tests/blts-opengles2-tests/bin/blts-opengles2-tests -C /opt/tests/blts-opengles2-tests/cnf/blts-opengles2-perf.cnf -l /var/log/tests/blts/OpenGL-Enumerate_GL_extensions_fbdev.log -en "OpenGL-Enumerate GL extensions" -ws fbdev</step>
+      </case>
+      <case name="OpenGL-Enumerate EGL extensions"
+        description="Lists all EGL extensions"
+        type="Functional positive">
+        <step>/opt/tests/blts-opengles2-tests/bin/blts-opengles2-tests -C /opt/tests/blts-opengles2-tests/cnf/blts-opengles2-perf.cnf -l /var/log/tests/blts/OpenGL-Enumerate_EGL_extensions_fbdev.log -en "OpenGL-Enumerate EGL extensions" -ws fbdev</step>
+      </case>
+      <case name="OpenGL-Enumerate EGL configs"
+        description="Lists all EGL configurations"
+        type="Functional positive">
+        <step>/opt/tests/blts-opengles2-tests/bin/blts-opengles2-tests -C /opt/tests/blts-opengles2-tests/cnf/blts-opengles2-perf.cnf -l /var/log/tests/blts/OpenGL-Enumerate_EGL_configs_fbdev.log -en "OpenGL-Enumerate EGL configs" -ws fbdev</step>
+      </case>
+      <case name="OpenGL-Simple triangle"
+        description="Draws simple three vertex rotating triangle"
+        type="Functional positive">
+        <step>/opt/tests/blts-opengles2-tests/bin/blts-opengles2-tests -C /opt/tests/blts-opengles2-tests/cnf/blts-opengles2-perf.cnf -l /var/log/tests/blts/OpenGL-Simple_triangle_fbdev.log -en "OpenGL-Simple triangle" -ws fbdev</step>
+      </case>
+      <get>
+        <file>/var/log/tests/blts/OpenGL-Enumerate_GL_extensions_fbdev.log</file>
+        <file>/var/log/tests/blts/OpenGL-Enumerate_EGL_extensions_fbdev.log</file>
+        <file>/var/log/tests/blts/OpenGL-Enumerate_EGL_configs_fbdev.log</file>
+        <file>/var/log/tests/blts/OpenGL-Simple_triangle_fbdev.log</file>
       </get>
     </set>
 


### PR DESCRIPTION
Add command-line option to choose between testing on wayland (`EGL_PLATFORM=wayland`) and fbdev (`EGL_PLATFORM=fbdev`) and necessary context setup/teardown code.
